### PR TITLE
Update cassava_trait.obo

### DIFF
--- a/cassava_trait.obo
+++ b/cassava_trait.obo
@@ -5,6 +5,7 @@ auto-generated-by: OBO-Edit 2.3.1
 default-namespace: CassavaTraitOntology
 namespace-id-rule: * CO_334:$sequence(7,0100000,0999999)$
 ontology: co_334
+owl-axioms: Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\nPrefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)\nPrefix(xml:=<http://www.w3.org/XML/1998/namespace>)\nPrefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\nPrefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)\n\n\nOntology(\nDeclaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#id>))\n\n\nAnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/co_334.owl#CO_334:0004024> \"CO_334:0001064\"^^xsd:string)\nAnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/co_334.owl#CO_334:0004025> \"CO_334:0001065\"^^xsd:string)\nAnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/co_334.owl#CO_334:0004026> \"CO_334:0010486\"^^xsd:string)\nAnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/co_334.owl#CO_334:0004027> \"CO_334:0001065\"^^xsd:string)\nAnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/co_334.owl#CO_334:0004028> \"CO_334:0001065\"^^xsd:string)\nAnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/co_334.owl#CO_334:0004029> \"CO_334:0001065\"^^xsd:string)\n)
 
 [Term]
 id: CO_334:0000000
@@ -8982,6 +8983,74 @@ namespace: CassavaMethod
 def: "Calculation of gari swelling power using the volume of the gari and water mixture after swelling and the initial volume of the gari sample before swelling" [CO:curators]
 is_a: CO_334:0001002 ! Methods
 relationship: method_of CO_334:0001064 ! Gari quality
+
+[Term]
+id: CO_334:0004024
+name: Gari particle size
+namespace: cassava_trait
+def: "The partricle size indicate the granular size of the gari samples measure at 0-300, ps300-500, ps500-800, and ps800 um" []
+synonym: "granular size(um)" EXACT []
+is_a: CO_334:0000004 ! Quality trait
+
+[Term]
+id: CO_334:0004025
+name: Partricle size of gari at ps800 (µm)
+namespace: cassava_trait
+def: "Partricle size of gari measure at ps800 (800 µm) refers to as the large particles size of gari" [CO:curators]
+synonym: "ps800 (µm)" EXACT []
+is_a: CO_334:0001000 ! Variables
+relationship: variable_of CO_334:0004024 ! Gari particle size
+relationship: variable_of CO_334:0004026 ! Measurement: Gari particle size_method
+relationship: variable_of CO_334:0100692 ! um
+created_by: Ukoabasi Ekanem
+creation_date: 9/27/2023
+
+[Term]
+id: CO_334:0004026
+name: Measurement: Gari particle size_method
+namespace: CassavaMethod
+def: "The particle size of gari sample is determined by placing 50 g of gari samples on a tier of sieves arranged in a decreasing aperture size: ps800 (800 μm) for the large particles,ps500–800 (500 μm) for medium-sized particles, ps300–500 (300 μm) for small particles, and ps0–300 for the smallest particles, collected in a base pan and fractions retain on each sieve are weighed using an electrionic balance and expressed as a percentage of the initial sample weight." []
+is_a: CO_334:0001002 ! Methods
+relationship: method_of CO_334:0000374 ! Gari content
+
+[Term]
+id: CO_334:0004027
+name: Partricle size of gari at 500-800 (µm)
+namespace: cassava_trait
+def: "Partricle size of gari measure at ps500–800 (500 μm) refers to as the medium-sized particles of gari" [CO:curators]
+synonym: "ps500-800 (µm)" EXACT []
+is_a: CO_334:0001000 ! Variables
+relationship: variable_of CO_334:0004024 ! Gari particle size
+relationship: variable_of CO_334:0004026 ! Measurement: Gari particle size_method
+relationship: variable_of CO_334:0100692 ! um
+created_by: Ukoabasi Ekanem
+creation_date: 9/27/2023
+
+[Term]
+id: CO_334:0004028
+name: Partricle size of gari at ps300–500 μm
+namespace: cassava_trait
+def: "Partricle size of gari measure at ps300–500 (300 μm) refers to as the  small particles of gari" [CO:curators]
+synonym: "ps300-500 (µm)" EXACT []
+is_a: CO_334:0001000 ! Variables
+relationship: variable_of CO_334:0004024 ! Gari particle size
+relationship: variable_of CO_334:0004026 ! Measurement: Gari particle size_method
+relationship: variable_of CO_334:0100692 ! um
+created_by: Ukoabasi Ekanem
+creation_date: 9/27/2023
+
+[Term]
+id: CO_334:0004029
+name: Partricle size of gari at ps0–300 μm
+namespace: cassava_trait
+def: "Partricle size of gari measure at ps0–300 refers to as the  smallest particles of gari" [CO:curators]
+synonym: "ps0–300 (µm)" EXACT []
+is_a: CO_334:0001000 ! Variables
+relationship: variable_of CO_334:0004024 ! Gari particle size
+relationship: variable_of CO_334:0004026 ! Measurement: Gari particle size_method
+relationship: variable_of CO_334:0100692 ! um
+created_by: Ukoabasi Ekanem
+creation_date: 9/27/2023
 
 [Term]
 id: CO_334:0010000


### PR DESCRIPTION
Added new trait Gari particle size with variables of 0-300, ps300-500, ps500-800, and ps800 um

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] An OBO file generated from an OWL file
- [ ] New terms
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] Term updates
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] CHECKS
  - [ ] New variables have a parent trait ID 
    - [ ] New variables have methods and scales 
  - [ ] The OBO file has been validated
    - [ ] checked in cassavabase
    - [ ] checked CropOntology
    
    

